### PR TITLE
[2024/08/20 Fix/admin front 이미지 폼 추가 & description 추가

### DIFF
--- a/src/main/java/com/sparta/studytrek/domain/rank/dto/RankResponseDto.java
+++ b/src/main/java/com/sparta/studytrek/domain/rank/dto/RankResponseDto.java
@@ -10,14 +10,17 @@ public class RankResponseDto {
     private Long id;
     private Long campId;
     private String campName;
+    private String description;
     private Integer ranking;
     private String campImage;
     private Integer likesCount;
 
-    public RankResponseDto(Long id, Long campId, String campName, Integer ranking, String campImage, Integer likesCount) {
+    public RankResponseDto(Long id, Long campId, String campName, String description,
+        Integer ranking, String campImage, Integer likesCount) {
         this.id = id;
         this.campId = campId;
         this.campName = campName;
+        this.description = description;
         this.ranking = ranking;
         this.campImage = campImage;
         this.likesCount = likesCount;

--- a/src/main/java/com/sparta/studytrek/domain/rank/service/RankService.java
+++ b/src/main/java/com/sparta/studytrek/domain/rank/service/RankService.java
@@ -10,7 +10,6 @@ import com.sparta.studytrek.domain.rank.dto.RankResponseDto;
 import com.sparta.studytrek.domain.rank.entity.Rank;
 import com.sparta.studytrek.domain.rank.repository.RankRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -18,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RankService {
@@ -44,6 +42,7 @@ public class RankService {
             savedRank.getId(),
             savedRank.getCamp().getId(),
             savedRank.getCamp().getName(),
+            savedRank.getCamp().getDescription(),
             savedRank.getRanking(),
             savedRank.getCamp().getImageUrl(),
             savedRank.getCamp().getLikesCount()
@@ -69,34 +68,19 @@ public class RankService {
      */
     @Transactional(readOnly = true)
     public RankListResponseDto getAllRanks(Pageable pageable) {
-        // 로그 추가 - 메서드 시작
-        log.info("getAllRanks 메서드 호출 - Pageable: {}", pageable);
-
-        Page<Rank> rankPage;
-        try {
-            rankPage = rankRepository.findAllOrderByRankingAsc(pageable);
-            log.info("랭크 데이터 페이징 조회 성공 - 총 페이지: {}, 총 요소: {}", rankPage.getTotalPages(), rankPage.getTotalElements());
-        } catch (Exception e) {
-            log.error("랭크 데이터 페이징 조회 실패", e);
-            throw e;  // 원래 예외를 다시 던져서 처리
-        }
-
+        Page<Rank> rankPage = rankRepository.findAllOrderByRankingAsc(pageable);
         List<RankResponseDto> rankList = rankPage.getContent().stream()
-            .map(rank -> {
-                log.info("Rank 데이터 매핑 - Rank ID: {}, Camp ID: {}", rank.getId(), rank.getCamp().getId());
-                return new RankResponseDto(
-                    rank.getId(),
-                    rank.getCamp().getId(),
-                    rank.getCamp().getName(),
-                    rank.getRanking(),
-                    rank.getCamp().getImageUrl(),
-                    rank.getCamp().getLikesCount()
-                );
-            })
+            .map(rank -> new RankResponseDto(
+                rank.getId(),
+                rank.getCamp().getId(),
+                rank.getCamp().getName(),
+                rank.getCamp().getDescription(),
+                rank.getRanking(),
+                rank.getCamp().getImageUrl(),
+                rank.getCamp().getLikesCount()
+            ))
             .toList();
-
-        // 로그 추가 - 메서드 종료
-        log.info("getAllRanks 메서드 종료 - 조회된 Rank 수: {}", rankList.size());
-        return new RankListResponseDto(rankList, rankPage.getTotalPages(), rankPage.getTotalElements());
+        return new RankListResponseDto(rankList, rankPage.getTotalPages(),
+            rankPage.getTotalElements());
     }
 }

--- a/src/main/resources/static/css/rank/Rank.css
+++ b/src/main/resources/static/css/rank/Rank.css
@@ -5,9 +5,16 @@ body {
 }
 
 .emoji {
-    font-size: 2rem; /* 이모지 크기 조정 */
+    font-size: 2rem;
     display: inline-block;
     margin-bottom: 15px;
+}
+
+.camp-description {
+    font-size: 17px;
+    font-weight: bold;
+    display: flex;
+    justify-content: center;
 }
 
 .container {

--- a/src/main/resources/static/js/rank/Rank.js
+++ b/src/main/resources/static/js/rank/Rank.js
@@ -50,6 +50,7 @@ function displayRanks(data) {
   data.forEach(rank => {
     const campId = rank.campId;
     const campName = rank.campName;
+    const description = rank.description;
     const campImage = rank.campImage;
     const ranking = rank.ranking;
     const likesCount = rank.likesCount || 0;
@@ -71,6 +72,7 @@ function displayRanks(data) {
         <div class="emoji">${emoji}</div>
         <h3>${campName}</h3>
         <img src="${campImage}" alt="${campName} Image" class="camp-image">
+        <p class="camp-description">${description}</p>
         <div class="rating">${ranking}등</div>
     `;
 

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -78,6 +78,7 @@
         <h2>부트캠프 등록</h2>
         <input type="text" id="bootcampName" placeholder="부트캠프 이름">
         <input type="text" id="description" placeholder="부트캠프 한 줄 설명">
+        <input type="file" id="imageFile" accept="image/*">
         <button id="btnRegister" class="btn-register">등록하기</button>
       </div>
     </div>


### PR DESCRIPTION
## 📌 What is this PR ?

0. 로컬과 서버 배포에서의 Rank 프론트 UI에서 조회의 차이에 대한 해결 

➡️  createRank 메서드는 어드민의 권한에서 API를 직접 호출해야만 생성이 되는 방식이기에 인위적으로 데이터를 삽입만 하는 방식으로는 순위 데이터가 들어가지 않았기에 조회가 안 되었었음, 이를 어드민 페이지에 이미지 폼을 추가하여 해결

2. 어드민 프론트에 이미지 파일 넣는 폼 추가

3. 기존 랭크 조회 서비스 로직에 로그 코드 삭제

4. 랭크 페이지 JS 수정 (description 추가)

<br/>

## 🔎 Additions / Changes

Additions

- 어드민 프론트에 이미지 파일 넣는 폼 추가

- 응답 dto, JS 수정 (description 추가)

Changes

- 기존 랭크 서비스 로직 로그 삭제 
<br/>

## 📷 Screenshot


| Rank 프론트 | 스크린샷 |
| --- | --- |
| UI | ![image](https://github.com/user-attachments/assets/1d203c19-a56a-4daa-9004-16bd7470d511) |
| DB | ![image](https://github.com/user-attachments/assets/cd245cc4-665e-4aca-9e1e-e73d4db94ed1) |
| DB | ![image](https://github.com/user-attachments/assets/5064cc23-20b9-4486-8385-dac0e51f6a8a) |

<br/>

## ✅ Test Checklist
- [x] 테스트 확인
